### PR TITLE
feat: add additional repositoriy ids for sonatype nexus to settings.xml

### DIFF
--- a/settings.xml
+++ b/settings.xml
@@ -21,7 +21,22 @@
       <password>${SONATYPE_PASSWORD}</password>
     </server>
     <server>
+      <id>sonatype-nexus-staging</id>
+      <username>${SONATYPE_USERNAME}</username>
+      <password>${SONATYPE_PASSWORD}</password>
+    </server>
+    <server>
       <id>oss-sonatype-snapshots</id>
+      <username>${SONATYPE_USERNAME}</username>
+      <password>${SONATYPE_PASSWORD}</password>
+    </server>
+    <server>
+      <id>sonatype-nexus-snapshots</id>
+      <username>${SONATYPE_USERNAME}</username>
+      <password>${SONATYPE_PASSWORD}</password>
+    </server>
+    <server>
+      <id>ossrh</id>
       <username>${SONATYPE_USERNAME}</username>
       <password>${SONATYPE_PASSWORD}</password>
     </server>


### PR DESCRIPTION
It seems that each project is using a different id to refer to sonatype, so we need to either add them here, or change every single project out there....